### PR TITLE
fix(core): stop() sends correct opcode in mop mode + raise RECV_TIMEOUT

### DIFF
--- a/packages/core/src/emitters/robot.emitter.ts
+++ b/packages/core/src/emitters/robot.emitter.ts
@@ -75,7 +75,7 @@ export enum MANUAL_MODE {
 export type ManualMode = (typeof MANUAL_MODE)[keyof typeof MANUAL_MODE];
 
 const MODE_CHANGE_TIMEOUT = 5000;
-const RECV_TIMEOUT = 5000;
+const RECV_TIMEOUT = 30000;
 
 const CONSUMABLE_TYPE_RESET = {
   [CONSUMABLE_TYPE.MAIN_BRUSH]: 1,
@@ -218,10 +218,16 @@ export class Robot extends TypedEmitter<RobotEvents> {
   }
 
   async stop(): Promise<void> {
-    await this.sendRecv('DEVICE_AUTO_CLEAN_REQ', 'DEVICE_AUTO_CLEAN_RSP', {
-      ctrlValue: CTRL_VALUE.STOP,
-      cleanType: 2,
-    });
+    if (this.device.mode?.value === DeviceMode.VALUE.MOP) {
+      await this.sendRecv('DEVICE_MOP_FLOOR_CLEAN_REQ', 'DEVICE_MOP_FLOOR_CLEAN_RSP', {
+        ctrlValue: CTRL_VALUE.STOP,
+      });
+    } else {
+      await this.sendRecv('DEVICE_AUTO_CLEAN_REQ', 'DEVICE_AUTO_CLEAN_RSP', {
+        ctrlValue: CTRL_VALUE.STOP,
+        cleanType: 2,
+      });
+    }
 
     if (this.device.system.supports(DEVICE_CAPABILITY.MAP_PLANS) && this.device.map) {
       const { id, restrictedZones } = this.device.map;


### PR DESCRIPTION
…UT to 30s

stop() was unconditionally sending DEVICE_AUTO_CLEAN_REQ; the robot ignores that command in mop mode, causing a 15s timeout + AxiosError. Now mirrors pause() by checking device.mode and sending DEVICE_MOP_FLOOR_CLEAN_REQ when in MOP mode.

Also raises RECV_TIMEOUT from 5 000 ms to 30 000 ms — DEVICE_AUTO_CLEAN_RSP can legitimately arrive after 15s while the robot is still processing map-plan steps; the robot cleans correctly, confirming a late response rather than a missing one.